### PR TITLE
Use secondaryAxis formatting for tooltip display

### DIFF
--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -30,7 +30,7 @@ class Tooltip extends PureComponent {
               <table>
                 <tbody>
                   {(secondaryAxis.stacked
-                    ? [...datums].reverse()
+                    ? [...datums].reverse().map(d => secondaryAxis.format(d))
                     : datums).map((d, i) =>
                     (<tr key={i}>
                       <td>
@@ -45,8 +45,8 @@ class Tooltip extends PureComponent {
                         }}
                       >
                         {Math.floor(d.secondary) < d.secondary
-                          ? Math.round(d.secondary * 100) / 100
-                          : d.secondary}
+                          ? secondaryAxis.format(Math.round(d.secondary * 100) / 100)
+                          : secondaryAxis.format(d.secondary)}
                       </td>
                     </tr>)
                   )}

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -30,7 +30,7 @@ class Tooltip extends PureComponent {
               <table>
                 <tbody>
                   {(secondaryAxis.stacked
-                    ? [...datums].reverse().map(d => secondaryAxis.format(d.secondary))
+                    ? [...datums].reverse()
                     : datums).map((d, i) =>
                     (<tr key={i}>
                       <td>

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -30,7 +30,7 @@ class Tooltip extends PureComponent {
               <table>
                 <tbody>
                   {(secondaryAxis.stacked
-                    ? [...datums].reverse().map(d => secondaryAxis.format(d))
+                    ? [...datums].reverse().map(d => secondaryAxis.format(d.secondary))
                     : datums).map((d, i) =>
                     (<tr key={i}>
                       <td>


### PR DESCRIPTION
Uses the `secondaryAxis` component's formatting function for tooltip rendering.