### PR TITLE
Respect passed-in tickFormat

### DIFF
--- a/src/utils/buildAxis.linear.js
+++ b/src/utils/buildAxis.linear.js
@@ -313,7 +313,7 @@ export default function buildAxisLinear({
         : scale.domain(),
     format:
       tickFormat || scale.tickFormat
-        ? scale.tickFormat(tickFormat)
+        ? (tickFormat || scale.tickFormat)(tickFormat)
         : Utils.identity,
     spacing: Math.max(tickSizeInner, 0) + tickPadding
   }

--- a/src/utils/buildAxis.linear.js
+++ b/src/utils/buildAxis.linear.js
@@ -313,7 +313,7 @@ export default function buildAxisLinear({
         : scale.domain(),
     format:
       tickFormat || scale.tickFormat
-        ? (tickFormat || scale.tickFormat)(tickFormat)
+        ? tickFormat || scale.tickFormat(tickFormat)
         : Utils.identity,
     spacing: Math.max(tickSizeInner, 0) + tickPadding
   }


### PR DESCRIPTION
The `tickFormat` passed in is ignored.

[Relevant twitter thread](https://www.twitter.com/tannerlinsley/status/1146508977716355072).