### PR TITLE
chore(actions): add cache to NPM dependencies on GitHub actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,43 +2,41 @@ name: react-charts publish
 on:
   push:
     branches:
-      - 'next'
+      - "master"
+      - "next"
+      - "1.x"
   pull_request:
 
 jobs:
   # test:
-  #   name: 'node ${{ matrix.node }} ${{ matrix.os }} '
-  #   runs-on: '${{ matrix.os }}'
+  #   name: 'Node ${{ matrix.node }}'
+  #   runs-on: ubuntu-latest
   #   strategy:
   #     matrix:
-  #       os: [ubuntu-latest]
-  #       node: [12]
+  #       node: [10, 12, 14]
   #   steps:
+  #     - uses: actions/checkout@v2
   #     - uses: actions/setup-node@v1
   #       with:
   #         node-version: ${{ matrix.node }}
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 1
-  #     - run: npm i -g yarn
-  #     - run: yarn --frozen-lockfile
+  #     - name: Install dependencies
+  #       uses: bahmutov/npm-install@v1
   #     - run: yarn test:ci
 
   publish-module:
-    name: 'Publish Module to NPM'
+    name: "Publish Module to NPM"
     # needs: test
-    if: github.ref == 'refs/heads/next' #publish only when merged in master, not on PR
+    # publish only when merged in master on original repo, not on PR
+    if: github.repository == 'tannerlinsley/react-charts' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/next' || github.ref == 'refs/heads/1.x')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
           registry-url: https://registry.npmjs.org/
-      - run: npm i -g yarn
-      - run: yarn --frozen-lockfile
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
       - run: npx semantic-release@17
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "release": {
     "branches": [
+      "1.x",
       "master",
       {
         "name": "next",


### PR DESCRIPTION
This uses [bahmutov/npm-install](https://github.com/bahmutov/npm-install) to install NPM dependencies with caching without any configuration.