### PR TITLE
docs: fix text overflow on homepage.

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -33,7 +33,7 @@ const Home = props => {
               className="absolute transform right-0 top-1/2 h-0 lg:h-full scale-150 translate-x-1/2 xl:translate-x-1/5 -translate-y-1/2"
               alt="React Charts Emblem"
             />
-            <div className="grid grid-cols-12 gap-8">
+            <div className="grid grid-cols-12 lg:gap-8">
               <div className="col-span-12 lg:col-span-6 ">
                 <div className="text-center lg:text-left md:max-w-2xl md:mx-auto ">
                   <h1 className="text-4xl tracking-tight leading-10 font-extrabold text-gray-900 sm:leading-none sm:text-6xl lg:text-5xl xl:text-6xl">


### PR DESCRIPTION
Greetings.

This PR fixes a overflow issue on the homepage caused by grid at `<380px`.

| Before   | After   |
|---|---|
| <img src="https://user-images.githubusercontent.com/44864604/103222362-3de8b300-494a-11eb-880e-b954f578ce55.png" height="500px" />   | <img src="https://user-images.githubusercontent.com/44864604/103222952-37a70680-494b-11eb-835a-f84cd2029ef4.png" height="500px" />  |