### PR TITLE
Fix `module` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": "react-tools/react-charts",
   "main": "index.js",
-  "module": "dist/react-charts.mjs",
+  "module": "dist/react-charts.min.mjs",
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"


### PR DESCRIPTION
This change allows `react-charts` to be used in [Vite](https://vitejs.dev/) projects.

Although this doesn't fix the fact there's a CommonJS `require()` in the `.mjs` file (https://github.com/tannerlinsley/react-charts/issues/149), Vite seems to be able to process it still, presumably due to the CommonJS interop layer.