### PR TITLE
Add shouldNice option to AxisOptionsBase

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -241,6 +241,7 @@ export type AxisOptionsBase = {
   minTickPaddingForRotation?: number
   tickLabelRotationDeg?: number
   tickCount?: number
+  shouldNice?: boolean
   innerBandPadding?: number
   outerBandPadding?: number
   innerSeriesBandPadding?: number

--- a/src/utils/buildAxis.linear.ts
+++ b/src/utils/buildAxis.linear.ts
@@ -42,6 +42,7 @@ function defaultAxisOptions<TDatum>(
     outerSeriesBandPadding: options.outerSeriesBandPadding ?? 0,
     show: options.show ?? true,
     stacked: options.stacked ?? false,
+    shouldNice: options.shouldNice ?? true,
   }
 }
 
@@ -117,24 +118,25 @@ function buildTimeAxis<TDatum>(
     return value
   })
 
-  let shouldNice = true
+  let shouldNice = options.shouldNice
 
-  if (typeof options.min === 'number') {
+  // see https://stackoverflow.com/a/2831422
+  if (Object.prototype.toString.call(options.min) === '[object Date]') {
     minValue = min([options.min, minValue as Date])
     shouldNice = false
   }
 
-  if (typeof options.max === 'number') {
+  if (Object.prototype.toString.call(options.max) === '[object Date]') {
     maxValue = max([options.max, maxValue as Date])
     shouldNice = false
   }
 
-  if (typeof options.hardMin === 'number') {
+  if (Object.prototype.toString.call(options.hardMin) === '[object Date]') {
     minValue = options.hardMin
     shouldNice = false
   }
 
-  if (typeof options.hardMax === 'number') {
+  if (Object.prototype.toString.call(options.hardMax) === '[object Date]') {
     maxValue = options.hardMax
     shouldNice = false
   }
@@ -245,7 +247,7 @@ function buildLinearAxis<TDatum>(
         return value
       })
 
-  let shouldNice = true
+  let shouldNice = options.shouldNice
 
   if (typeof options.min === 'number') {
     minValue = min([options.min, minValue as number])


### PR DESCRIPTION
- added `shouldNice: boolean` option to `AxisOptionsBase` type
- using this value as default when deciding whether to nice or not
- fixed checks for extrema when building a time axis