### PR TITLE
Cast min and max argument when Dates to get rid of TS error

### DIFF
--- a/src/utils/buildAxis.linear.ts
+++ b/src/utils/buildAxis.linear.ts
@@ -122,12 +122,12 @@ function buildTimeAxis<TDatum>(
 
   // see https://stackoverflow.com/a/2831422
   if (Object.prototype.toString.call(options.min) === '[object Date]') {
-    minValue = min([options.min, minValue as Date])
+    minValue = min([options.min, minValue] as Date[])
     shouldNice = false
   }
 
   if (Object.prototype.toString.call(options.max) === '[object Date]') {
-    maxValue = max([options.max, maxValue as Date])
+    maxValue = max([options.max, maxValue] as Date[])
     shouldNice = false
   }
 


### PR DESCRIPTION
There was a TS problem when trying to guess the return value of `min` and `max` in this case. Casting it helped.

Originally I had something broken in my local copy so I missed this but all should be fixed now.

Sorry!