### PR TITLE
fix: make it possible to override font-family in style prop

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -201,6 +201,7 @@ export function Chart<TDatum>({
       {...rest}
       className={`ReactChart ${className || ''}`}
       style={{
+        fontFamily: 'sans-serif',
         ...style,
         position: 'absolute',
         width,
@@ -682,11 +683,7 @@ function ChartInner<TDatum>({
 
   return (
     <ChartContextProvider value={useGetLatest(contextValue)}>
-      <div
-        style={{
-          fontFamily: 'sans-serif',
-        }}
-      >
+      <div>
         <svg
           ref={svgRef}
           style={{


### PR DESCRIPTION
This is a fix to allow styles to override the default `fontFamily` by passing it into the `style` prop.

This should fix the issue I opened https://github.com/tannerlinsley/react-charts/issues/248